### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v3.0.1] - 2025-10-14
+
+### Fixed
+
+- `unescapeTextPropertyValue` throws if it contains DQUOTE.
+
 ## [v3.0.0] - 2025-10-14
 
 ### Added
@@ -202,7 +208,8 @@ and this project adheres to
   - Has getters/setters for the following properties: `DTSTART`, `DTEND`,
     `SUMMARY`, `DESCRIPTION` and `LOCATION`.
 
-[unreleased]: https://github.com/olillin/iamcal/compare/v3.0.0...dev
+[unreleased]: https://github.com/olillin/iamcal/compare/v3.0.1...dev
+[v3.0.1]: https://github.com/olillin/iamcal/compare/v3.0.0...v3.0.1
 [v3.0.0]: https://github.com/olillin/iamcal/compare/v2.1.2...v3.0.0
 [v2.1.2]: https://github.com/olillin/iamcal/compare/v2.1.1...v2.1.2
 [v2.1.1]: https://github.com/olillin/iamcal/compare/v2.1.0...v2.1.1

--- a/tests/parse/deserializeProperty.spec.ts
+++ b/tests/parse/deserializeProperty.spec.ts
@@ -199,6 +199,24 @@ it('can parse values containing colons', () => {
     expect(property).toStrictEqual(expected)
 })
 
+it('allows one quote', () => {
+    const serialized = 'SUMMARY:"value'
+
+    const property = deserializeProperty(serialized)
+
+    const expected = new Property('SUMMARY', '"value')
+    expect(property).toStrictEqual(expected)
+})
+
+it('allows two quotes', () => {
+    const serialized = 'SUMMARY:"valu"e'
+
+    const property = deserializeProperty(serialized)
+
+    const expected = new Property('SUMMARY', '"valu"e')
+    expect(property).toStrictEqual(expected)
+})
+
 it('throws if no colon is present', () => {
     const serialized = 'LOCATION=Incorrect format'
 
@@ -225,18 +243,6 @@ it('throws if quoted parameter has leading characters', () => {
 
 it('throws if quoted parameter has trailing characters', () => {
     const serialized = 'SUMMARY;key="a"b:value'
-
-    expect(() => deserializeProperty(serialized)).toThrow()
-})
-
-it('throws if quoted value has leading characters', () => {
-    const serialized = 'SUMMARY:a"value"'
-
-    expect(() => deserializeProperty(serialized)).toThrow()
-})
-
-it('throws if quoted value has trailing characters', () => {
-    const serialized = 'SUMMARY:"value"b'
 
     expect(() => deserializeProperty(serialized)).toThrow()
 })

--- a/tests/property/escape/unescapeTextPropertyValue.spec.ts
+++ b/tests/property/escape/unescapeTextPropertyValue.spec.ts
@@ -82,3 +82,15 @@ it('calculates bad escape index correctly', () => {
         unescapeTextPropertyValue(value)
     }).toThrow(new SyntaxError("Bad escaped character '\\a' at position 6"))
 })
+
+it('allows one quote', () => {
+    const value = 'this " is allowed'
+    const unescaped = unescapeTextPropertyValue(value)
+    expect(unescaped).toBe('this " is allowed')
+})
+
+it('allows multiple quotes', () => {
+    const value = 'this " is " allowed'
+    const unescaped = unescapeTextPropertyValue(value)
+    expect(unescaped).toBe('this " is " allowed')
+})


### PR DESCRIPTION
## Changes

### Fixed

- `unescapeTextPropertyValue` throws if it contains DQUOTE.
